### PR TITLE
Update requirements and fix deprecation warning with opencv-sift

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,8 +4,8 @@ import argparse
 import cv2 as cv
 
 
-FEATURES_DISTANCE = 0.3 
-MIN_MATCHES = 50 
+FEATURES_DISTANCE = 0.3
+MIN_MATCHES = 50
 
 
 def collect_imgs(directory):
@@ -24,7 +24,7 @@ def collect_imgs(directory):
 	"""
 
 	imgs = []
-	
+
 	for file in os.listdir(directory):
 		if(file.lower().endswith(('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif'))):
 			path = os.path.join(directory, file)
@@ -38,7 +38,7 @@ def collect_imgs(directory):
 
 def detect_features(imgs):
 	"""
-	Detect and computes features and descriptors. 
+	Detect and computes features and descriptors.
 
 	SIFT (Scale-Invariant Feature Transform) feature detection algorithm is
 	used to calculate the features and descriptors of each image.
@@ -54,7 +54,7 @@ def detect_features(imgs):
 		List of the images to compare with keypoins and descriptors
 	"""
 
-	sift = cv.xfeatures2d.SIFT_create()
+	sift = cv.SIFT_create()
 
 	for img in imgs:
 		img['kp'], img['des'] = sift.detectAndCompute(img['f'], None)
@@ -82,7 +82,7 @@ def similarity_check(imgs):
 	"""
 
 	duplicates = []
-	
+
 	for i1 in range(len(imgs)):
 		for i2 in range(i1 + 1, len(imgs)):
 			FLANN_INDEX_KDTREE = 1
@@ -106,7 +106,7 @@ def similarity_check(imgs):
 				h2, w2 = imgs[i2]['f'].shape[:2]
 				duplicates.append(imgs[i2 if h1*w1 > h2*w2 else i1]['p'])
 
-	return duplicates			
+	return duplicates
 
 
 def delete(duplicates):
@@ -155,7 +155,7 @@ def argparser():
 		MIN_MATCHES = args.min_matches
 	if(args.features_distance):
 		FEATURES_DISTANCE = args.features_distance
-	
+
 	return args
 
 
@@ -168,7 +168,7 @@ def main():
 	imgs = collect_imgs(args.directory)
 	imgs = detect_features(imgs)
 	duplicates = similarity_check(imgs)
-	if args.delete: 
+	if args.delete:
 		delete(duplicates)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-opencv-python==3.4.2.16
-opencv-contrib-python==3.4.2.16
+opencv-python==4.4.0.42
+opencv-contrib-python==4.4.0.42


### PR DESCRIPTION
This fixes my errors, when I cloned your repository.
I got this error, when trying to `pip install` your requirements:
```
ERROR: Could not find a version that satisfies the requirement opencv-python==3.4.2.16 (from -r requirements.txt (line 1)) (from versions: 3.4.8.29, 3.4.9.31, 3.4.9.33, 3.4.10.35, 3.4.10.37, 3.4.11.39, 3.4.11.41, 4.1.2.30, 4.2.0.32, 4.2.0.34, 4.3.0.36, 4.3.0.38, 4.4.0.40, 4.4.0.42)
ERROR: No matching distribution found for opencv-python==3.4.2.16 (from -r requirements.txt (line 1))
```
Thus I bumped the opencv and opencv-contrib versions to `4.4.0.42`.
I also got a deprecation warning when trying your sample code:
```
SIFT_create DEPRECATED: cv.xfeatures2d.SIFT_create() is deprecated due SIFT transfer to the main repository.
```
Here is the related [issue](https://github.com/opencv/opencv/issues/16736) and corresponding [pull request](https://github.com/opencv/opencv/pull/17119).


Thats why removing the `xfeatures2d` in the code fixes the problem.

I hope this helps other, who would like to use this awesome script.